### PR TITLE
Update typescript.md

### DIFF
--- a/docs/installation/typescript.md
+++ b/docs/installation/typescript.md
@@ -10,7 +10,7 @@ npm install dayjs --save
 ```
 Import and use in your Typescript file
 ```js
-import * as dayjs from 'dayjs'
+import dayjs from 'dayjs';
 dayjs().format()
 ```
 


### PR DESCRIPTION
Changing from

```js
import * as dayjs from 'dayjs';
```

to

```js
import dayjs from 'dayjs';
```

was the only way I was able to use dayjs in an Angular 10 app. No other way worked, including changing the `compilerOptions`