### PR TITLE
Suggestion: little notice in tables for short forms of units for m and M being for minutes and months

### DIFF
--- a/docs/display/difference.md
+++ b/docs/display/difference.md
@@ -17,7 +17,7 @@ To get the difference in another unit of measurement, pass that measurement as t
 
 ```js
 const date1 = dayjs('2019-01-25');
-date1.diff("2018-06-05", 'month'); // 7
+date1.diff('2018-06-05', 'month'); // 7
 ```
 
 Units are case insensitive, and support plural and short forms. Note, short forms are case sensitive.

--- a/docs/display/difference.md
+++ b/docs/display/difference.md
@@ -8,19 +8,19 @@ This indicates the difference between two date-time in the specified unit.
 To get the difference in milliseconds, use `dayjs#diff`.
 
 ```js
-const date1 = dayjs("2019-01-25");
-const date2 = dayjs("2018-06-05");
+const date1 = dayjs('2019-01-25');
+const date2 = dayjs('2018-06-05');
 date1.diff(date2); // 20214000000 default milliseconds
 ```
 
 To get the difference in another unit of measurement, pass that measurement as the second argument.
 
 ```js
-const date1 = dayjs("2019-01-25");
-date1.diff("2018-06-05", "month"); // 7
+const date1 = dayjs('2019-01-25');
+date1.diff("2018-06-05", 'month'); // 7
 ```
 
-Units are case insensitive, and support plural and short forms. Please, note that short forms for month (M) and minute (m) are case sensitives.
+Units are case insensitive, and support plural and short forms. Note, short forms are case sensitive.
 
 #### List of all available units
 
@@ -39,6 +39,6 @@ Units are case insensitive, and support plural and short forms. Please, note tha
 By default, `dayjs#diff` will truncate the result to zero decimal places, returning an integer. If you want a floating point number, pass true as the third argument.
 
 ```js
-const date1 = dayjs("2019-01-25");
-date1.diff("2018-06-05", "month", true); // 7.645161290322581
+const date1 = dayjs('2019-01-25');
+date1.diff('2018-06-05', 'month', true); // 7.645161290322581
 ```

--- a/docs/display/difference.md
+++ b/docs/display/difference.md
@@ -6,20 +6,21 @@ title: Difference
 This indicates the difference between two date-time in the specified unit.
 
 To get the difference in milliseconds, use `dayjs#diff`.
+
 ```js
-const date1 = dayjs('2019-01-25')
-const date2 = dayjs('2018-06-05')
-date1.diff(date2) // 20214000000 default milliseconds
+const date1 = dayjs("2019-01-25");
+const date2 = dayjs("2018-06-05");
+date1.diff(date2); // 20214000000 default milliseconds
 ```
 
 To get the difference in another unit of measurement, pass that measurement as the second argument.
 
 ```js
-const date1 = dayjs('2019-01-25')
-date1.diff('2018-06-05', 'month') // 7
+const date1 = dayjs("2019-01-25");
+date1.diff("2018-06-05", "month"); // 7
 ```
 
-Units are case insensitive, and support plural and short forms.
+Units are case insensitive, and support plural and short forms. Please, note that short forms for month (M) and minute (m) are case sensitives.
 
 #### List of all available units
 
@@ -35,10 +36,9 @@ Units are case insensitive, and support plural and short forms.
 | `second`      | `s`       | Second                                   |
 | `millisecond` | `ms`      | Millisecond                              |
 
-
-By default, `dayjs#diff` will truncate the result to zero decimal places, returning an integer. If you want a floating point number, pass true as the third argument. 
+By default, `dayjs#diff` will truncate the result to zero decimal places, returning an integer. If you want a floating point number, pass true as the third argument.
 
 ```js
-const date1 = dayjs('2019-01-25')
-date1.diff('2018-06-05', 'month', true) // 7.645161290322581
+const date1 = dayjs("2019-01-25");
+date1.diff("2018-06-05", "month", true); // 7.645161290322581
 ```

--- a/docs/display/difference.md
+++ b/docs/display/difference.md
@@ -8,16 +8,16 @@ This indicates the difference between two date-time in the specified unit.
 To get the difference in milliseconds, use `dayjs#diff`.
 
 ```js
-const date1 = dayjs('2019-01-25');
-const date2 = dayjs('2018-06-05');
-date1.diff(date2); // 20214000000 default milliseconds
+const date1 = dayjs('2019-01-25')
+const date2 = dayjs('2018-06-05')
+date1.diff(date2) // 20214000000 default milliseconds
 ```
 
 To get the difference in another unit of measurement, pass that measurement as the second argument.
 
 ```js
-const date1 = dayjs('2019-01-25');
-date1.diff('2018-06-05', 'month'); // 7
+const date1 = dayjs('2019-01-25')
+date1.diff('2018-06-05', 'month') // 7
 ```
 
 Units are case insensitive, and support plural and short forms. Note, short forms are case sensitive.
@@ -39,6 +39,6 @@ Units are case insensitive, and support plural and short forms. Note, short form
 By default, `dayjs#diff` will truncate the result to zero decimal places, returning an integer. If you want a floating point number, pass true as the third argument.
 
 ```js
-const date1 = dayjs('2019-01-25');
-date1.diff('2018-06-05', 'month', true); // 7.645161290322581
+const date1 = dayjs('2019-01-25')
+date1.diff('2018-06-05', 'month', true) // 7.645161290322581
 ```

--- a/docs/get-set/get.md
+++ b/docs/get-set/get.md
@@ -9,7 +9,7 @@ In general:
 dayjs().get(unit) === dayjs()[unit]()
 ```
 
-Units are case insensitive, and support plural and short forms.
+Units are case insensitive, and support plural and short forms. Please, note that short forms for month (M) and minute (m) are case sensitives.
 
 ```js
 dayjs().get('year')

--- a/docs/get-set/get.md
+++ b/docs/get-set/get.md
@@ -16,9 +16,9 @@ dayjs().get('year')
 dayjs().get('month') // start 0
 dayjs().get('date')
 dayjs().get('hour')
-dayjs().get('minute');
-dayjs().get('second');
-dayjs().get('millisecond');
+dayjs().get('minute')
+dayjs().get('second')
+dayjs().get('millisecond')
 ```
 
 #### List of all available units

--- a/docs/get-set/get.md
+++ b/docs/get-set/get.md
@@ -9,7 +9,7 @@ In general:
 dayjs().get(unit) === dayjs()[unit]()
 ```
 
-Units are case insensitive, and support plural and short forms. Please, note that short forms for month (M) and minute (m) are case sensitives.
+Units are case insensitive, and support plural and short forms. Note, short forms are case sensitive.
 
 ```js
 dayjs().get('year')

--- a/docs/manipulate/add.md
+++ b/docs/manipulate/add.md
@@ -6,7 +6,7 @@ title: Add
 Returns a cloned Day.js object with a specified amount of time added.
 
 ```js
-dayjs().add(7, 'day');
+dayjs().add(7, 'day')
 ```
 
 Units are case insensitive, and support plural and short forms. Note, short forms are case sensitive.

--- a/docs/manipulate/add.md
+++ b/docs/manipulate/add.md
@@ -2,13 +2,14 @@
 id: add
 title: Add
 ---
+
 Returns a cloned Day.js object with a specified amount of time added.
 
 ```js
-dayjs().add(7, 'day')
+dayjs().add(7, "day");
 ```
 
-Units are case insensitive, and support plural and short forms.
+Units are case insensitive, and support plural and short forms. Please, note that short forms for month (M) and minute (m) are case sensitives.
 
 #### List of all available units
 

--- a/docs/manipulate/add.md
+++ b/docs/manipulate/add.md
@@ -6,10 +6,10 @@ title: Add
 Returns a cloned Day.js object with a specified amount of time added.
 
 ```js
-dayjs().add(7, "day");
+dayjs().add(7, 'day');
 ```
 
-Units are case insensitive, and support plural and short forms. Please, note that short forms for month (M) and minute (m) are case sensitives.
+Units are case insensitive, and support plural and short forms. Note, short forms are case sensitive.
 
 #### List of all available units
 


### PR DESCRIPTION
Hello,

Maybe I'm just an edge case, but since english is not my first language, sometimes the language is another obstacle for me achieve my purposes. I spent a great amount of time, wrestling with a problem only later I identified: in the docs is said that units are case insensitive, so Months, MONTHS, etc. But of course, the documentation didn't explicit said that this was the case for short hands, and I was using with this expectations.

Now, I know I should compare the table, where is *very explicit* the relationship, short forms being only an alternative to units names and maybe this is just a little patch for a problem only I had, but I decided to submit anyway, if thinks it makes sense a little extra help for developers like me :) 

I only append my notice in the texts where the table appears and of course, maybe I wrote in the wrong way.

Great job! I like a lot this lib.