### PR TITLE
Make consistent with docs for `max`

### DIFF
--- a/docs/get-set/min.md
+++ b/docs/get-set/min.md
@@ -9,5 +9,5 @@ Returns the minimum (most distant past) of the given Day.js instances.
 ```js
 dayjs.extend(minMax)
 
-dayjs.min([dayjs(), dayjs('2018-01-01'), dayjs('2019-01-01')])
+dayjs.min(dayjs(), dayjs('2018-01-01'), dayjs('2019-01-01'))
 ```


### PR DESCRIPTION
The docs for `max` don't pass an array but individual arguments