### PR TITLE
the .from() method shows "in x time" instead of "x time ago"

### DIFF
--- a/docs/plugin/relative-time.md
+++ b/docs/plugin/relative-time.md
@@ -8,7 +8,7 @@ RelativeTime adds `.from` `.to` `.fromNow` `.toNow` APIs to formats date to rela
 var relativeTime = require('dayjs/plugin/relativeTime')
 dayjs.extend(relativeTime)
 
-dayjs().from(dayjs('1990')) // 2 years ago
+dayjs().to(dayjs('1990')) // 2 years ago
 dayjs().from(dayjs(), true) // 2 years
 
 dayjs().fromNow()


### PR DESCRIPTION
inserting a `Date `type into the `to()` method ex: `dayjs().to(dayjs(Date))`  method shows "x time ago". that is different from what was being shown in the docs.
the `.from()` method shows "in X time" when used similarly.
the variables of Date type had data in this format: `x: Date = "2016-01-01 00:00:00"`