### PR TITLE
fix: timezone dependent on utc comment

### DIFF
--- a/docs/plugin/timezone.md
+++ b/docs/plugin/timezone.md
@@ -6,8 +6,8 @@ title: Timezone
 Timezone adds `dayjs.tz` `.tz` `.tz.guess` `.tz.setDefault` APIs to parse or display between time zones.
 
 ```javascript
-var utc = require('dayjs/plugin/utc') // dependent on utc plugin
-var timezone = require('dayjs/plugin/timezone')
+var utc = require('dayjs/plugin/utc')
+var timezone = require('dayjs/plugin/timezone') // dependent on utc plugin
 dayjs.extend(utc)
 dayjs.extend(timezone)
 


### PR DESCRIPTION
Moved comment `dependent on utc plugin` to the line with timezone because the timezone plugin is dependent on the utc plugin, not the utc plugin is dependent on the utc plugin.

It took me some time to figure out what I was doing wrong and why I'm getting `Cannot set property '$timezone' of undefined` error. After some searching, I found on gitter that the timezone plugin is dependent on the utc plugin, so your documentation needs a minor fix.