### PR TITLE
Update plural-get-set.md

### DIFF
--- a/docs/plugin/plural-get-set.md
+++ b/docs/plugin/plural-get-set.md
@@ -2,7 +2,7 @@
 id: plural-get-set
 title: PluralGetSet
 ---
-PluralGetSet adds plural getter & setter APIs `.milliseconds()`, `.seconds()`, `.minutes()`, `.hours()`, `.days()`, `.weeks()`, `.isoWeeks()`, `.months()`, `.quarters()`, `.years()`, '.dates()'.
+PluralGetSet adds plural getter & setter APIs `.milliseconds()`, `.seconds()`, `.minutes()`, `.hours()`, `.days()`, `.weeks()`, `.isoWeeks()`, `.months()`, `.quarters()`, `.years()`, `.dates()`.
 
 ```javascript
 var pluralGetSet = require('dayjs/plugin/pluralGetSet')


### PR DESCRIPTION
Uses backticks for monospace font