### PR TITLE
Remove ordinal day of month from supported inputs

### DIFF
--- a/docs/parse/string-format.md
+++ b/docs/parse/string-format.md
@@ -57,7 +57,6 @@ dayjs("12-25-2001", ["YYYY", "YYYY-MM-DD"], 'es', true);
 | `ZZ`   | -0500            | Compact offset from UTC, 2-digits |
 | `A`    | AM PM            | Post or ante meridiem, upper-case |
 | `a`    | am pm            | Post or ante meridiem, lower-case |
-| `Do`   | 1st... 31st      | Day of Month with ordinal         |
 
 
 


### PR DESCRIPTION
Link: https://day.js.org/docs/en/parse/string-format#list-of-all-available-parsing-tokens

`Do` (ordinal day-of-month) input unlike other inputs in this table needs an extra plugin.

It could be confusing for readers, as it was for me!

Also, it doesn't exist in the API documentation.
https://github.com/iamkun/dayjs/blob/dev/docs/en/API-reference.md#list-of-all-available-formats