### PR TITLE
Add ES2015 snippets for timezone plugin use

### DIFF
--- a/docs/plugin/timezone.md
+++ b/docs/plugin/timezone.md
@@ -7,7 +7,9 @@ Timezone adds `dayjs.tz` `.tz` `.tz.guess` `.tz.setDefault` APIs to parse or dis
 
 ```javascript
 var utc = require('dayjs/plugin/utc')
+// import * as utc from 'dayjs/plugin/utc' // ES 2015
 var timezone = require('dayjs/plugin/timezone') // dependent on utc plugin
+// import * as timezone from 'dayjs/plugin/timezone' // ES 2015
 dayjs.extend(utc)
 dayjs.extend(timezone)
 


### PR DESCRIPTION
I couldn't find anywhere in the documentation that actually gave me the correct syntax to import and use these plugins in my Typescript project (`import 'dayjs/plugin/utc'` didn't result in a variable to feed to `.extend`, and when I tried `import { utc } from 'dayjs/plugin/utc'` it couldn't find an object to import), so I tried this and it seems to work fine, suggest adding for users who are not using the `require` syntax.