### PR TITLE
Fix typo in ObjectSupport example

### DIFF
--- a/docs/plugin/object-support.md
+++ b/docs/plugin/object-support.md
@@ -12,14 +12,14 @@ dayjs.extend(objectSupport);
 dayjs({
   year: 2010,
   month: 1,
-  day: 12
+  date: 12
 });
 dayjs.utc({
   year: 2010,
   month: 1,
-  day: 12
+  date: 12
 });
-dayjs().set({ year: 2010, month: 1, day: 12 })
+dayjs().set({ year: 2010, month: 1, date: 12 })
 dayjs().add({ M: 1 })
 dayjs().subtract({ month: 1 })
 ```


### PR DESCRIPTION
The example sets 12 as a day of the week (`day`) but it makes more sense as a day of the month (`date`).