### PR TITLE
fix: add reminder for setters that dayjs objects are immutable

### DIFF
--- a/docs/get-set/date.md
+++ b/docs/get-set/date.md
@@ -8,8 +8,8 @@ Gets or sets the day of the month.
 Accepts numbers from 1 to 31. If the range is exceeded, it will bubble up to the months.
 
 ```js
-dayjs().date()
-dayjs().date(1)
+dayjs().date() // gets day of current month
+dayjs().date(1) // returns new dayjs object
 ```
 
 >`dayjs#date` is for the date of the month, and `dayjs#day` is for the day of the week.

--- a/docs/get-set/day.md
+++ b/docs/get-set/day.md
@@ -8,8 +8,8 @@ Gets or sets the day of the week.
 Accepts numbers from 0 (Sunday) to 6 (Saturday). If the range is exceeded, it will bubble up to other weeks.
 
 ```js
-dayjs().day()
-dayjs().day(0)
+dayjs().day() // gets day of current week
+dayjs().day(0) // returns new dayjs object
 ```
 
 >`dayjs#date` is for the date of the month, and `dayjs#day` is for the day of the week.

--- a/docs/get-set/get-set.md
+++ b/docs/get-set/get-set.md
@@ -5,6 +5,8 @@ title: Get + Set
 
 Day.js uses overloaded getters and setters, that is to say, calling these methods without parameters acts as a getter, and calling them with a parameter acts as a setter.
 
+As dayjs objects are immutable, all setters will return a new dayjs instance.
+
 These map to the corresponding function on the native `Date` object.
 
 ```js

--- a/docs/get-set/hour.md
+++ b/docs/get-set/hour.md
@@ -8,6 +8,6 @@ Gets or sets the hour.
 Accepts numbers from 0 to 23. If the range is exceeded, it will bubble up to the day.
 
 ```js
-dayjs().hour()
-dayjs().hour(12)
+dayjs().hour() // gets current hour
+newDate = dayjs().hour(12) // returns new dayjs object
 ```

--- a/docs/get-set/iso-week.md
+++ b/docs/get-set/iso-week.md
@@ -10,6 +10,6 @@ Gets or sets the [ISO week of the year](https://en.wikipedia.org/wiki/ISO_week_d
 ```javascript
 dayjs.extend(isoWeek)
 
-dayjs().isoWeek()
-dayjs().isoWeek(2)
+dayjs().isoWeek() // gets the current ISO week of the year
+newDate = dayjs().isoWeek(2) // returns new dayjs object
 ```

--- a/docs/get-set/iso-weekday.md
+++ b/docs/get-set/iso-weekday.md
@@ -10,6 +10,6 @@ Gets or sets the [ISO day of the week](https://en.wikipedia.org/wiki/ISO_week_da
 ```javascript
 dayjs.extend(isoWeek)
 
-dayjs().isoWeekday()
+dayjs().isoWeekday() // gets the current ISO day of he week
 dayjs().isoWeekday(1); // Monday
 ```

--- a/docs/get-set/millisecond.md
+++ b/docs/get-set/millisecond.md
@@ -8,6 +8,6 @@ Gets or sets the millisecond.
 Accepts numbers from 0 to 999. If the range is exceeded, it will bubble up to the seconds.
 
 ```js
-dayjs().millisecond()
-dayjs().millisecond(1)
+dayjs().millisecond() // gets current millisecond
+dayjs().millisecond(1) // returns new dayjs object
 ```

--- a/docs/get-set/minute.md
+++ b/docs/get-set/minute.md
@@ -8,6 +8,6 @@ Gets or sets the minutes.
 Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the hour.
 
 ```js
-dayjs().minute()
-dayjs().minute(59)
+dayjs().minute() // gets current minute
+dayjs().minute(59) // returns new dayjs object
 ```

--- a/docs/get-set/month.md
+++ b/docs/get-set/month.md
@@ -8,8 +8,8 @@ Gets or sets the month.
 Accepts numbers from 0 to 11. If the range is exceeded, it will bubble up to the year.
 
 ```js
-dayjs().month()
-dayjs().month(0)
+dayjs().month() // gets current month
+dayjs().month(0) // returns new dayjs object
 ```
 
 >Months are zero indexed, so January is month 0.

--- a/docs/get-set/quarter.md
+++ b/docs/get-set/quarter.md
@@ -10,5 +10,5 @@ Gets or sets the quarter.
 dayjs.extend(quarterOfYear)
 
 dayjs('2010-04-01').quarter() // 2
-dayjs('2010-04-01').quarter(2)
+dayjs('2010-04-01').quarter(2) // returns new dayjs object
 ```

--- a/docs/get-set/second.md
+++ b/docs/get-set/second.md
@@ -8,6 +8,6 @@ Gets or sets the second.
 Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the minutes.
 
 ```js
-dayjs().second()
-dayjs().second(1)
+dayjs().second() // gets current second
+dayjs().second(1) // returns new dayjs object
 ```

--- a/docs/get-set/week.md
+++ b/docs/get-set/week.md
@@ -10,5 +10,5 @@ Gets or sets the week of the year.
 dayjs.extend(weekOfYear)
 
 dayjs('2018-06-27').week() // 26
-dayjs('2018-06-27').week(5) // set week
+dayjs('2018-06-27').week(5) // returns new dayjs object
 ```

--- a/docs/get-set/year.md
+++ b/docs/get-set/year.md
@@ -6,6 +6,6 @@ title: Year
 Gets or sets the year.
 
 ```js
-dayjs().year()
-dayjs().year(2000)
+dayjs().year() // gets current year
+dayjs().year(2000) // returns new dayjs object
 ```


### PR DESCRIPTION
On occasion I stumbled about the fact that the setters don't change the object, but return a new one. The very first page of dayjs says so, but it took me a few seconds to remember, when searching for strange effects in my program 😄 