### PR TITLE
fix: add results in time zone examples to clarify usage

### DIFF
--- a/docs/parse/string.md
+++ b/docs/parse/string.md
@@ -3,10 +3,12 @@ id: string
 title: String
 ---
 
-Parse the given string in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format and return a Day.js object instance.
+Parse the given string in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (a space instead of the 'T' is allowed) and return a Day.js object instance.
 
 ```js
 dayjs('2018-04-04T16:00:00.000Z')
+dayjs('2018-04-13 19:18:17.040+02:00')
+dayjs('2018-04-13 19:18')
 ```
 
 >For consistent results parsing anything **other** than ISO 8601 strings, you should use [String + Format](./string-format).

--- a/docs/timezone/converting-to-zone.md
+++ b/docs/timezone/converting-to-zone.md
@@ -9,8 +9,11 @@ Change the time zone and update the offset and return a Day.js object instance.
 ```javascript
 dayjs.extend(utc)
 dayjs.extend(timezone)
-dayjs("2013-11-18 11:55").tz("America/Toronto")
-dayjs("2013-11-18 11:55").tz("America/Toronto", true)
+
+// this example runs in time zone 'Europe/Berlin' (offset +01:00)
+dayjs("2013-11-18T11:55:20") // '2013-11-18T11:55:20+01:00'
+dayjs("2013-11-18T11:55:20").tz("America/Toronto") // '2013-11-18T05:55:20-05:00'
+dayjs("2013-11-18T11:55:20").tz("America/Toronto", true) // '2013-11-18T11:55:20-05:00'
 ```
 
 On passing a second parameter as true, only the timezone (and offset) is updated, keeping the local time same. 

--- a/docs/timezone/parsing-in-zone.md
+++ b/docs/timezone/parsing-in-zone.md
@@ -9,7 +9,7 @@ Parse date-time string in the given timezone and return a Day.js object instance
 ```javascript
 dayjs.extend(utc)
 dayjs.extend(timezone)
-dayjs.tz("2013-11-18 11:55", "America/Toronto")
+dayjs.tz("2013-11-18T11:55:20", "America/Toronto") // '2013-11-18T11:55:20-05:00'
 ```
 
 If you know the format of an input string, you can use that to parse a date, the arguments are the same as [String + Format](../parse/string-format).

--- a/docs/timezone/timezone.md
+++ b/docs/timezone/timezone.md
@@ -16,8 +16,8 @@ dayjs.extend(timezone)
 
 // current time zone is 'Europe/Berlin' (offset +01:00)
 // Parsing
-dayjs.tz("2013-11-18T11:55:20", "America/Toronto") // '2013-11-18T11:55:20-05:00'
+dayjs.tz("2013-11-18 11:55:20", "America/Toronto") // '2013-11-18T11:55:20-05:00'
 
 // Converting (from time zone 'Europe/Berlin'!)
-dayjs("2013-11-18T11:55:20").tz("America/Toronto") // '2013-11-18T05:55:20-05:00'
+dayjs("2013-11-18 11:55:20").tz("America/Toronto") // '2013-11-18T05:55:20-05:00'
 ```

--- a/docs/timezone/timezone.md
+++ b/docs/timezone/timezone.md
@@ -3,7 +3,8 @@ id: timezone
 title: Time Zone
 ---
 
-Day.js supports time zone via the [Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) in [supported environments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#Browser_compatibility). By using the native API, no extra bytes of timezone data need to be included in code bundle.
+Day.js supports time zone via the [Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) in [supported environments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#Browser_compatibility). By using the native API, no extra bytes of timezone data need to be included in code bundle.  
+The list of all time zone names can be fount in the [IANA database](https://www.iana.org/time-zones).
 
 For legacy or unsupported environments, please use a proper [polyfill](https://github.com/formatjs/date-time-format-timezone). 
 
@@ -13,7 +14,10 @@ For legacy or unsupported environments, please use a proper [polyfill](https://g
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-dayjs.tz("2014-06-01 12:00", "America/New_York")
+// current time zone is 'Europe/Berlin' (offset +01:00)
+// Parsing
+dayjs.tz("2013-11-18T11:55:20", "America/Toronto") // '2013-11-18T11:55:20-05:00'
 
-dayjs("2014-06-01 12:00").tz("America/New_York")
+// Converting (from time zone 'Europe/Berlin'!)
+dayjs("2013-11-18T11:55:20").tz("America/Toronto") // '2013-11-18T05:55:20-05:00'
 ```


### PR DESCRIPTION
Quite a few issues describe problems with the timezone plugin that result
from misinterpretation of parsing versus converting.