### PR TITLE
fix: add list of separator characters to customParseFormat plugin

### DIFF
--- a/docs/parse/string-format.md
+++ b/docs/parse/string-format.md
@@ -61,5 +61,6 @@ dayjs("12-25-2001", ["YYYY", "YYYY-MM-DD"], 'es', true);
 | `X`    | 1410715640.579   | Unix timestamp                    |
 | `x`    | 1410715640579    | Unix ms timestamp                 |
 
-
+List of all recognized separator characters:  
+`-_:.,()/`
 


### PR DESCRIPTION
Some issues of dayjs concern the separator characters - specially the comma. Add a list of allowed separator characters to parse documentation.