### PR TITLE
fix: document the use of units in isAfter, isBefore and isBetween

### DIFF
--- a/docs/query/is-after.md
+++ b/docs/query/is-after.md
@@ -7,10 +7,10 @@ This indicates whether the Day.js object is after the other supplied date-time.
 ```js
 dayjs().isAfter(dayjs('2011-01-01')) // default milliseconds
 ```
-If you want to limit the granularity to a unit other than milliseconds, pass it as the second parameter.
+If you want to limit the granularity to a unit other than milliseconds, pass it as the second parameter. In that case the comparision respects the given unit and the units above.
 
 ```js
-dayjs().isAfter('2011-01-01', 'year')
+dayjs().isAfter('2011-01-01', 'month') // compares month and year
 ```
 
 Units are case insensitive, and support plural and short forms.

--- a/docs/query/is-before.md
+++ b/docs/query/is-before.md
@@ -8,10 +8,10 @@ This indicates whether the Day.js object is before the other supplied date-time.
 ```js
 dayjs().isBefore(dayjs('2011-01-01')) // default milliseconds
 ```
-If you want to limit the granularity to a unit other than milliseconds, pass it as the second parameter.
+If you want to limit the granularity to a unit other than milliseconds, pass it as the second parameter. In that case the comparision respects the given unit and the units above.
 
 ```js
-dayjs().isBefore('2011-01-01', 'year')
+dayjs().isBefore('2011-01-01', 'month') // compares month and year
 ```
 
 Units are case insensitive, and support plural and short forms.

--- a/docs/query/is-between.md
+++ b/docs/query/is-between.md
@@ -12,10 +12,10 @@ dayjs.extend(isBetween)
 dayjs('2010-10-20').isBetween('2010-10-19', dayjs('2010-10-25')) 
 // default milliseconds
 ```
-If you want to limit the granularity to a unit other than milliseconds, pass it as the third parameter.
+If you want to limit the granularity to a unit other than milliseconds, pass it as the third parameter. In that case the comparision respects the given unit and the units above.
 
 ```js
-dayjs().isBetween('2010-10-19', '2010-10-25', 'year')
+dayjs().isBetween('2010-10-19', '2010-10-25', 'month') // compares month and year
 ```
 
 Units are case insensitive, and support plural and short forms.


### PR DESCRIPTION
The detailed consequences of using a unit in e.g. 'isBetween' is not clearly documented. Added some comments.