### PR TITLE
docs: switch from unpkg to jsdelivr

### DIFF
--- a/docs/i18n/i18n.md
+++ b/docs/i18n/i18n.md
@@ -11,7 +11,7 @@ You can load multiple locales and switch between them easily.
 
 [List of supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale)
 
-There's also a [locale.json](https://unpkg.com/dayjs/locale.json) file contains the list of all supported locales in the root of each release.
+There's also a [locale.json](https://cdn.jsdelivr.net/npm/dayjs@1/locale.json) file contains the list of all supported locales in the root of each release.
 
 More details on each of the parts of the locale bundle and the way to update or customize locale can be found in the [customization](../../customization/customization) section.
 

--- a/docs/i18n/loading-into-browser.md
+++ b/docs/i18n/loading-into-browser.md
@@ -25,8 +25,8 @@ var customLocale = window.dayjs_locale_zh_cn // zh-cn -> zh_cn
 Day.js is available on [CDN](../installation/browser#cdn-resource).
 
 ```html
-<!-- CDN example (unpkg) -->
-<script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-<script src="https://unpkg.com/dayjs@1.8.21/locale/zh-cn.js"></script>
+<!-- CDN example (jsDelivr) -->
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/locale/zh-cn.js"></script>
 <script>dayjs.locale('zh-cn')</script>
 ```

--- a/docs/installation/browser.md
+++ b/docs/installation/browser.md
@@ -15,8 +15,8 @@ title: Browser
 >Day.js can be included by way of a CDN provider like [cdnjs.com](https://cdnjs.com/libraries/dayjs), [unpkg](https://unpkg.com/dayjs/) and [jsDelivr](https://www.jsdelivr.com/package/npm/dayjs) ...
 
 ```html
-<!-- CDN example (unpkg) -->
-<script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
+<!-- CDN example (jsDelivr) -->
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
 <script>dayjs().format()</script>
 ```
 

--- a/docs/plugin/loading-into-browser.md
+++ b/docs/plugin/loading-into-browser.md
@@ -15,8 +15,8 @@ Loading plugin on demand.
 Day.js is available on [CDN](../installation/browser#cdn-resource).
 
 ```html
-<!-- CDN example (unpkg) -->
-<script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
-<script src="https://unpkg.com/dayjs@1.8.21/plugin/utc.js"></script>
+<!-- CDN example (jsDelivr) -->
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dayjs@1/plugin/utc.js"></script>
 <script>dayjs.extend(window.dayjs_plugin_utc)</script>
 ```

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -10,7 +10,7 @@
 
 // List of projects/orgs using your project for the users page.
 const users = []
-const markdownPlugins = require('./plugin') 
+const markdownPlugins = require('./plugin')
 const siteConfig = {
   markdownPlugins: [markdownPlugins],
   title: 'Day.js', // Title for your website.
@@ -50,7 +50,7 @@ const siteConfig = {
   /* Colors for website */
   colors: {
     primaryColor: '#fb6052',
-    secondaryColor: '#eb6052'
+    secondaryColor: '#eb6052',
   },
 
   /* Custom fonts for website */
@@ -79,13 +79,13 @@ const siteConfig = {
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks.
     // theme: 'github'
-    themeUrl: 'https://cdn.jsdelivr.net/npm/highlight.js@9.12.0/styles/default.min.css'
+    themeUrl: 'https://cdn.jsdelivr.net/npm/highlight.js@9.12.0/styles/default.min.css',
   },
 
   // Add custom scripts here that would be placed in <script> tags.
   // scripts: ['https://buttons.github.io/buttons.js'],
 
-  // stylesheets: ['https://unpkg.com/bulma@0.7.5/css/bulma.min.css'],
+  // stylesheets: ['https://cdn.jsdelivr.net/npm/bulma@0.7.5/css/bulma.min.css'],
 
   // On page navigation for the current documentation page.
   onPageNav: 'separate',
@@ -111,8 +111,8 @@ const siteConfig = {
     apiKey: '015f468476ca8256cf1c8e8fb6d82cc3',
     indexName: 'dayjs',
     algoliaOptions: {
-      facetFilters: ["language:LANGUAGE"]
-    }
+      facetFilters: ['language:LANGUAGE'],
+    },
   },
 }
 


### PR DESCRIPTION
unpkg is unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues). I switched the documentation over to [jsDelivr](https://www.jsdelivr.com/) since it's actively maintained and is much more reliable due to its [fallback system](https://www.jsdelivr.com/network/infographic).

I also switched the version tags from `@1.8.21` to `@1` since it's really easy for the docs to get out of sync with the actual latest version. If a developer really needs a specific version, then they'll tag it themselves.