### PR TITLE
fix: document the use of floating point numbers in add and subtract

### DIFF
--- a/docs/manipulate/add.md
+++ b/docs/manipulate/add.md
@@ -30,3 +30,5 @@ Alternatively, you can use [durations](../durations/durations) to add to Day.js 
 ```js
 dayjs().add(dayjs.duration({'days' : 1}))
 ```
+
+When decimal values are passed for **days** and **weeks**, they are rounded to the nearest integer before adding.

--- a/docs/manipulate/subtract.md
+++ b/docs/manipulate/subtract.md
@@ -11,3 +11,5 @@ dayjs().subtract(7, 'year')
 Units are case insensitive, and support plural and short forms.
 
 [List of all available units](../manipulate/add#list-of-all-available-units)
+
+When decimal values are passed for **days** and **weeks**, they are rounded to the nearest integer before subtracting.


### PR DESCRIPTION
Update documentation for `add` and `subtract` regarding floating point numbers as input values.