### PR TITLE
Update describe to example `.formNow` return value

### DIFF
--- a/docs/display/from-now.md
+++ b/docs/display/from-now.md
@@ -10,7 +10,7 @@ Returns the string of relative time from now.
 ```js
 dayjs.extend(relativeTime)
 
-dayjs('1999-01-01').fromNow() // 20 years ago
+dayjs('1999-01-01').fromNow() // 22 years ago
 ```
 
 If you pass true, you can get the value without the suffix.


### PR DESCRIPTION
>  ```js
> dayjs.extend(relativeTime)
> dayjs('1999-01-01').fromNow() // 20 years ago
> ```
>
>  If you pass true, you can get the value without the suffix.
> ```js
> dayjs.extend(relativeTime)
> dayjs('1999-01-01').fromNow(true) // 22 years
> ```
> 
> [Time from now `.fromNow(withoutSuffix?: boolean)` - RelativeTime · Day.js](https://day.js.org/docs/en/plugin/relative-time#time-from-now-fromnowwithoutsuffix-boolean)

I was confused about the difference between `20 years ago` and `22 years` 😕

so I fix similar value to `22 years`.