### PR TITLE
docs: Improved "plugin requirement" phrase

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -109,7 +109,7 @@ function Intro() {
       </div>
       <div className="hide">
         <translate desc="plugin">
-          This dependent on
+          This requires the
         </translate>
         <translate desc="plugin">
           plugin to work


### PR DESCRIPTION
I improved the phrasing of the `plugin requirement` notice.

This notice would parse to:
`This dependent on IsoWeek plugin to work`

With my proposed changes this would instead parse to:
`This requires the IsoWeek plugin to work`