### PR TITLE
doc: add note for longDateFormat

### DIFF
--- a/docs/plugin/locale-data.md
+++ b/docs/plugin/locale-data.md
@@ -49,3 +49,11 @@ instanceLocaleData.longDateFormat('L')
 instanceLocaleData.meridiem()
 instanceLocaleData.ordinal()
 ```
+
+
+Note: when you want use `longDateFormat('L')`, remember extend `localizedFormat`
+
+```js
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+dayjs.extend(localizedFormat);
+```


### PR DESCRIPTION
add a note for `longDateFormat` with 'L' to prevent user miss meet issues with `Cannot read properties of undefined (reading 'L')`