### PR TITLE
fix: demo bug

### DIFF
--- a/docs/display/unix-timestamp-milliseconds.md
+++ b/docs/display/unix-timestamp-milliseconds.md
@@ -7,7 +7,7 @@ This returns the number of milliseconds since the Unix Epoch of the Day.js objec
 
 ```js
 dayjs('2019-01-25').valueOf() // 1548381600000
-+dayjs(1548381600000) // 1548381600000
++dayjs('2019-01-25') // 1548381600000
 ```
 
 To get a Unix timestamp (the number of **seconds** since the epoch) from a Day.js object, you should use [Unix Timestamp](./unix-timestamp).


### PR DESCRIPTION
Unix Timestamp (milliseconds) show the wrong demo