### PR TITLE
docs: fix import example for ES 2015 at: loading-into-nodejs.md

### DIFF
--- a/docs/plugin/loading-into-nodejs.md
+++ b/docs/plugin/loading-into-nodejs.md
@@ -6,7 +6,7 @@ Loading plugin on demand.
 
 ```javascript
 var AdvancedFormat = require('dayjs/plugin/advancedFormat')
-// import AdvancedFormat from 'dayjs/plugin/advancedFormat' // ES 2015
+// import AdvancedFormat from 'dayjs/plugin/advancedFormat.js' // ES 2015
 
 dayjs.extend(AdvancedFormat) // use plugin
 ```


### PR DESCRIPTION
The import as described in the documentation does not work:

import AdvancedFormat from 'dayjs/plugin/advancedFormat' // ES 2015

It should be:

import AdvancedFormat from 'dayjs/plugin/advancedFormat.js' // ES 2015