### PR TITLE
Update typescript.md with alternative import that resolves ts(2349) error

### DIFF
--- a/docs/installation/typescript.md
+++ b/docs/installation/typescript.md
@@ -13,6 +13,14 @@ Import and use in your TypeScript file
 import * as dayjs from 'dayjs'
 dayjs().format()
 ```
+> ⚠️ Some TS repo have reported getting `this expression is not callable.
+  Type 'typeof dayjs' has no call signatures.ts(2349)`
+
+Alternative import 👇️ is a known resolution. 
+
+```ts
+import { default as dayjs } from 'dayjs';
+```
 
 #### Have trouble importing Day.js?
 


### PR DESCRIPTION
This update to the documentation is meant to support solving ts bug, with out the googlefoo to find and scroll through the discussion to find the solution. 

`This expression is not callable. Type 'typeof dayjs' has no call signatures.ts(2349)`